### PR TITLE
create task to write merged forced_src tables to parquet

### DIFF
--- a/bin.src/writeObjectTable.py
+++ b/bin.src/writeObjectTable.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from lsst.qa.explorer.writeParquet import WriteObjectTableTask
+WriteObjectTableTask.parseAndRun()
+

--- a/python/lsst/qa/explorer/table.py
+++ b/python/lsst/qa/explorer/table.py
@@ -1,0 +1,39 @@
+"""Implements ParquetTable object as a fake FitsCatalog dataset
+
+This allows the butler to read/write parquet files, as a stand-in
+until DM-13876 is implemented.
+"""
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import fastparquet
+from astropy.table import Table
+
+class ParquetTable(object):
+    """Shim to use butler to write pandas dataframe to parquet file
+
+    Parameters
+    ----------
+    df : `pandas.DataFrame`
+    engine : 'pyarrow' or 'fastparquet'
+        Backend used to write/read parquet files.
+    """
+    def __init__(self, df, engine='pyarrow'):
+        self.df = df
+        self.engine = engine
+
+    def writeFits(self, filename):
+        """Write dataframe to parquet (not FITS).
+        """
+        if self.engine=='pyarrow':
+            table = pa.Table.from_pandas(self.df)
+            pq.write_table(table, filename, compression='none')
+        elif self.engine=='fastparquet':
+            fastparquet.write(filename, self.df)
+
+    @classmethod
+    def readFits(cls, filename):
+        """Read parquet file (not FITS) into pandas DataFrame.
+        """
+        return pd.read_parquet(filename, engine=self.engine)
+

--- a/python/lsst/qa/explorer/writeParquet.py
+++ b/python/lsst/qa/explorer/writeParquet.py
@@ -1,0 +1,125 @@
+"""Command-line task and associated config for writing deepCoadd_obj table.
+
+The deepCoadd_obj table is a merged catalog of deepCoadd_meas, deepCoadd_forced_src and deepCoadd_ref
+catalogs for multiple bands.
+"""
+from lsst.daf.persistence.butler import Butler
+from lsst.pex.config import (Config, Field, ConfigField, ListField, DictField, ConfigDictField,
+                             ConfigurableField)
+from lsst.pipe.base import Task, CmdLineTask, ArgumentParser, TaskRunner, TaskError
+from lsst.coadd.utils import TractDataIdContainer
+from lsst.pipe.tasks.multiBand import MergeSourcesTask, MergeSourcesConfig
+from lsst.pipe.tasks.multiBand import _makeGetSchemaCatalogs
+from lsst.coadd.utils.coaddDataIdContainer import ExistingCoaddDataIdContainer
+
+
+import functools
+import re
+import pandas as pd
+
+from .table import ParquetTable
+
+
+class WriteObjectTableConfig(MergeSourcesConfig):
+    priorityList = ListField(dtype=str, default=['HSC-G', 'HSC-R', 'HSC-I', 'HSC-Z', 'HSC-Y'],
+                             doc="Priority-ordered list of bands for the merge.")    
+    engine = Field(dtype=str, default="pyarrow", doc="Parquet engine for writing (pyarrow or fastparquet)")
+
+class WriteObjectTableTask(MergeSourcesTask):
+    """Write filter-merged source tables to parquet
+    """
+    _DefaultName = "writeObjectTable"
+    ConfigClass = WriteObjectTableConfig
+
+    @property
+    def outputDataset(self):
+        """Tag to define dataset written by `MergeSourcesTask.write`
+
+        That is: `self.config.coaddName + "Coadd_" + self.outputDataset`
+        """
+        return 'obj'
+
+    @property
+    def inputDatasets(self):
+        """Names of table datasets to be merged
+        """
+        return ('forced_src', 'meas', 'ref')
+
+    def getSchemaCatalogs(self, x):
+        """Not using this function, but it must return a dictionary.
+        """
+        return {}
+
+    @classmethod
+    def _makeArgumentParser(cls):
+        """Create a suitable ArgumentParser.
+
+        We will use the ArgumentParser to get a list of data
+        references for patches; the RunnerClass will sort them into lists
+        of data references for the same patch. 
+
+        References first of self.inputDatasets, rather than
+        self.inputDataset (which parent class does.)
+        """
+        parser = ArgumentParser(name=cls._DefaultName)
+        parser.add_id_argument("--id", "deepCoadd_" + cls.inputDatasets[0],
+                               ContainerClass=ExistingCoaddDataIdContainer,
+                               help="data ID, e.g. --id tract=12345 patch=1,2 filter=g^r^i")
+        return parser
+
+
+    def readCatalog(self, patchRef):
+        """Read input catalogs
+
+        Read all the input datasets given by the 'inputDatasets'
+        attribute.
+
+        Parameters
+        ----------
+        patchRef : 
+            Data reference for patch
+
+        Returns
+        -------
+        Tuple consisting of filter name and a dict of catalogs, keyed by dataset
+        name
+        """
+        filterName = patchRef.dataId["filter"]
+        catalogDict = {}
+        for dataset in self.inputDatasets:
+            catalog = patchRef.get(self.config.coaddName + "Coadd_" + dataset, immediate=True)
+            self.log.info("Read %d sources from %s for filter %s: %s" % (len(catalog), dataset, filterName, patchRef.dataId))
+            catalogDict[dataset] = catalog
+        return filterName, catalogDict
+
+    def mergeCatalogs(self, catalogs, patchRef):
+        """Merge multiple catalogs.
+
+        Parameters
+        ----------
+        catalogs : `dict`
+            Mapping from filter names to dict of catalogs.
+
+        Returns
+        -------
+        catalog : `lsst.qa.explorer.table.ParquetTable`
+            Merged dataframe, with each column prefixed by
+            `filter_tag(filt)`, wrapped in the parquet writer shim class.
+        """
+
+        dfs = []
+        for filt, tableDict in catalogs.items():
+            for dataset, table in tableDict.items():
+                # Convert afwTable to pandas DataFrame
+                df = table.asAstropy().to_pandas().set_index('id', drop=True)
+
+                # Sort columns by name, to ensure matching schema among patches
+                df = df.reindex(sorted(df.columns), axis=1)
+
+                # Make columns a 3-level MultiIndex
+                df.columns = pd.MultiIndex.from_tuples([(dataset, filt, c) for c in df.columns], 
+                                                       names=('dataset', 'filter', 'column'))
+                dfs.append(df)
+
+        catalog = functools.reduce(lambda d1,d2 : d1.join(d2), dfs)
+        return ParquetTable(catalog, engine=self.config.engine)

--- a/ups/qa_explorer.table
+++ b/ups/qa_explorer.table
@@ -1,5 +1,3 @@
-setupRequired(pipe_analysis)
-
 setupRequired(afw)
 setupRequired(daf_persistence)
 setupRequired(pex_config)


### PR DESCRIPTION
This new CmdLineTask builds on MergeSourcesTask to merge
`deepCoadd_forced_src`, `deepCoadd_meas`, and `deepCoadd_ref`
tables from multiple filters into single
joined parquet tables, one per patch.  The output dataset is
`deepCoadd_object`, and gets loaded as a pandas dataframe
with a multi-level column index, such that you can retrieve
all the columns of a single table with, e.g., df['meas']['HSC-R'].