### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/python/lsst/qa/explorer/consolidateQATable.py
+++ b/python/lsst/qa/explorer/consolidateQATable.py
@@ -46,7 +46,7 @@ class ConsolidateQATableTask(CmdLineTask):
                                ContainerClass=TractQADataIdContainer)
         return parser
 
-    def run(self, patchRefList):
+    def runDataRef(self, patchRefList):
         df = pd.concat([patchRef.get().toDataFrame() for patchRef in patchRefList])
         patchRefList[0].put(ParquetTable(dataFrame=df), self.outputDataset)
 

--- a/python/lsst/qa/explorer/writeObjectTable.py
+++ b/python/lsst/qa/explorer/writeObjectTable.py
@@ -84,7 +84,7 @@ class WriteObjectTableTask(MergeSourcesTask):
             catalogDict[dataset] = catalog
         return filterName, catalogDict
 
-    def mergeCatalogs(self, catalogs, patchRef):
+    def run(self, catalogs, patchRef):
         """Merge multiple catalogs.
 
         Parameters

--- a/python/lsst/qa/explorer/writeParquet.py
+++ b/python/lsst/qa/explorer/writeParquet.py
@@ -92,7 +92,7 @@ class WriteObjectTableTask(MergeSourcesTask):
             catalogDict[dataset] = catalog
         return filterName, catalogDict
 
-    def mergeCatalogs(self, catalogs, patchRef):
+    def run(self, catalogs, patchRef):
         """Merge multiple catalogs.
 
         Parameters

--- a/python/lsst/qa/explorer/writeQATable.py
+++ b/python/lsst/qa/explorer/writeQATable.py
@@ -41,7 +41,7 @@ class PostprocessCatalogTask(CmdLineTask):
         return parser
 
 
-    def run(self, patchRef):
+    def runDataRef(self, patchRef):
         """Do calculations; write result
         """
         parq = patchRef.get()


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
